### PR TITLE
Making Moneropedia links blue again.

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -22,12 +22,12 @@ img {
 }
 
 /* Fix fragment jumps being ruined by the floating navbar */
-// *[id]:before { 
-//   display: block; 
-//   content: " "; 
-//   margin-top: -75px; 
-//   height: 75px; 
-//   visibility: hidden; 
+// *[id]:before {
+//   display: block;
+//   content: " ";
+//   margin-top: -75px;
+//   height: 75px;
+//   visibility: hidden;
 // }
 
 * {
@@ -109,10 +109,6 @@ p code {
 
 .instruction-list {
 	margin-right: 5px;
-}
-
-.moneropedia {
-	color: #505050;
 }
 
 .long-term {
@@ -209,8 +205,8 @@ text {
 	background-image: url('../images/li.svg');
 	background-size: 12px;
 	background-repeat: no-repeat;
-	background-position: 0px 5px; 
-	padding-left: 22px; 
+	background-position: 0px 5px;
+	padding-left: 22px;
 	margin-bottom: 12px;
 }
 
@@ -356,7 +352,7 @@ body {
 }
 
 .code-message {
-		
+
 }
 
 .body-language {
@@ -882,7 +878,7 @@ body:before {
 }
 
 @media (min-width: 991px) and (max-width: 1200px) {
-	
+
 	.box-green .inside {
 		height: 300px;
 		margin-bottom: 0;
@@ -968,7 +964,7 @@ body:before {
 	.navbar-default .navbar-nav > li > a {
 		text-align: left;
 	}
-	
+
 	.navbar-wrapper {
 		width: 100%;
 	}


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero-site/issues/247

One simple deletion:
```css
.moneropedia {
	color: #505050;
}
```

### Testing

I checked both monero-site and monero-forum for unintended changes this might cause:
* The CSS class is **not used** here in monero-forum repo.
* The class is only used once in monero-site repo: https://github.com/monero-project/monero-site/blob/master/_plugins/moneropedia.rb#L75 (the links we intend to change)
* I also looked into the history of the code (https://github.com/monero-project/monero-forum/commit/aa3e6e232d0aad32a33ffecd034ade4a9079a2b5#diff-4fab20fc9b7238f5f5307386f2b163ffR97) and have concluded that it was probably meant to fix an issue that is no longer present.  The other styles in that PR such as `.box-green .moneropedia` no longer select anything on the site.

Please let me know if there is anything else I should be aware of.

Cheers!