### PR TITLE
Update footer links

### DIFF
--- a/app/views/master.blade.php
+++ b/app/views/master.blade.php
@@ -61,9 +61,8 @@
       <div class="container">
           <div class="footer-links">
 	          <ul class="fa-ul">
-		          <li><i class="fa-li fa fa-dot-circle-o"></i><a href="//getmonero.org/legal/terms">Terms</a></li>
-		          <li><i class="fa-li fa fa-dot-circle-o"></i><a href="//getmonero.org/legal/privacy">Privacy</a></li>
-		          <li><i class="fa-li fa fa-dot-circle-o"></i><a href="//getmonero.org/legal/copyright">Copyright</a></li>
+		          <li><i class="fa-li fa fa-dot-circle-o"></i><a href="//getmonero.org/legal">Legal</a></li>
+		          <li><i class="fa-li fa fa-dot-circle-o"></i><a href="https://github.com/monero-project/monero-forum">Source Code</a></li>
 	          </ul>
       </div>
           <a class="footer-icon" href="https://getmonero.org/feed.xml"><i class="fa fa-2x fa-rss-square"></i></a>


### PR DESCRIPTION
The terms, privacy and copyright pages on getmonero.org were merged into a single page (monero-project/monero-site#455).

It looked a bit bare with just one link down there so I added a link to the forum's source too.